### PR TITLE
fix: handle Atom namespace in YouTube RSS link lookup

### DIFF
--- a/.github/workflows/update-bluesky-posts.yml
+++ b/.github/workflows/update-bluesky-posts.yml
@@ -30,8 +30,9 @@ jobs:
             doc.elements.each("feed/entry") do |entry|
               id = entry.elements["yt:videoId"].text
               title = entry.elements["title"].text
-              link = entry.elements["link[@rel=alternate]"].attributes["href"]
-              type = link.include?("/shorts/") ? "short" : "video"
+              link_el = entry.elements.to_a("link").find { |l| l.attributes["rel"] == "alternate" }
+              href = link_el ? link_el.attributes["href"] : ""
+              type = href.include?("/shorts/") ? "short" : "video"
               videos << {"id" => id, "title" => title, "type" => type}
             end
             puts({"videos" => videos}.to_yaml)


### PR DESCRIPTION
Fixes the `undefined method 'attributes' for nil:NilClass` error in the YouTube RSS step. REXML can't resolve `link[@rel=alternate]` due to the Atom default namespace — this switches to manually iterating link elements instead.