### PR TITLE
feat: Add CKAD Certification Badge

### DIFF
--- a/_includes/certifications.html
+++ b/_includes/certifications.html
@@ -1,0 +1,31 @@
+<section class="section certifications-section" id="certifications">
+    <h2 class="section-title">
+        <span class="iconify-inline" data-icon="mdi:certificate"></span>
+        Certifications
+    </h2>
+    <div class="cert-grid">
+        <a href="https://training.linuxfoundation.org/certification/verify/" class="cert-card" target="_blank" rel="noopener noreferrer">
+            <div class="cert-badge">
+                <img src="/assets/images/ckad-badge.png" alt="CKAD Badge" width="120" height="120" loading="lazy">
+            </div>
+            <div class="cert-info">
+                <h3 class="cert-title">Certified Kubernetes Application Developer (CKAD)</h3>
+                <p class="cert-issuer">The Linux Foundation / CNCF</p>
+                <div class="cert-meta">
+                    <span class="cert-date">
+                        <span class="iconify-inline" data-icon="mdi:calendar"></span>
+                        August 2023
+                    </span>
+                    <span class="cert-id">
+                        <span class="iconify-inline" data-icon="mdi:identifier"></span>
+                        LF-y7m6yi5kq4
+                    </span>
+                </div>
+                <span class="cert-verify">
+                    <span class="iconify-inline" data-icon="mdi:open-in-new"></span>
+                    View Credential
+                </span>
+            </div>
+        </a>
+    </div>
+</section>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -84,6 +84,8 @@
         <!-- Projects / Spacelift -->
         {% include cards.html %}
 
+        {% include certifications.html %}
+
         {% include speaker-bio.html %}
 
         {% include footer.html %}

--- a/assets/style.css
+++ b/assets/style.css
@@ -1835,6 +1835,126 @@ img {
     font-family: var(--font-code);
 }
 
+/* ===== CERTIFICATIONS ===== */
+.cert-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: var(--spacing-sm);
+    max-width: 800px;
+    margin: 0 auto;
+}
+
+.cert-card {
+    display: flex;
+    align-items: center;
+    gap: 1.25rem;
+    padding: 1.25rem 1.5rem;
+    background: var(--color-bg-secondary);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    color: var(--color-text-primary);
+    text-decoration: none;
+    transition: all var(--transition-normal);
+}
+
+.cert-card:hover {
+    background: var(--color-bg-tertiary);
+    border-color: var(--color-accent-cyan);
+    transform: translateY(-4px);
+    box-shadow: var(--shadow-md), var(--shadow-glow-cyan);
+    color: var(--color-text-primary);
+}
+
+.cert-badge {
+    flex-shrink: 0;
+    width: 90px;
+    height: 90px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.cert-badge img {
+    width: 90px;
+    height: 90px;
+    object-fit: contain;
+    border-radius: var(--radius-sm);
+}
+
+.cert-info {
+    flex: 1;
+    min-width: 0;
+}
+
+.cert-title {
+    font-size: 0.95rem;
+    font-weight: 600;
+    font-family: var(--font-heading);
+    margin-bottom: 0.25rem;
+    line-height: 1.3;
+}
+
+.cert-issuer {
+    font-size: 0.8rem;
+    color: var(--color-text-secondary);
+    margin-bottom: 0.5rem;
+}
+
+.cert-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-bottom: 0.5rem;
+}
+
+.cert-date,
+.cert-id {
+    font-size: 0.7rem;
+    font-family: var(--font-code);
+    color: var(--color-text-muted);
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+.cert-date .iconify-inline,
+.cert-id .iconify-inline {
+    margin: 0;
+    color: var(--color-accent-amber);
+    font-size: 0.9em;
+}
+
+.cert-verify {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    font-size: 0.75rem;
+    font-family: var(--font-code);
+    color: var(--color-accent-cyan);
+    transition: color var(--transition-normal);
+}
+
+.cert-card:hover .cert-verify {
+    color: var(--color-accent-amber);
+}
+
+.cert-verify .iconify-inline {
+    margin: 0;
+    font-size: 0.9em;
+}
+
+@media (max-width: 480px) {
+    .cert-card {
+        flex-direction: column;
+        text-align: center;
+        padding: 1.25rem;
+    }
+
+    .cert-meta {
+        justify-content: center;
+    }
+}
+
 /* ===== SPEAKER BIO ===== */
 .speaker-bio-card {
     max-width: 700px;


### PR DESCRIPTION
## What

Adds a **Certifications** section to the profile site featuring the CKAD (Certified Kubernetes Application Developer) badge.

## Details

- **New section** placed between Projects and Speaker Bio — natural flow: projects → certs → bio
- **New include:** `_includes/certifications.html` with a cert card showing:
  - CKAD badge image (already in `assets/images/ckad-badge.png`)
  - Title, issuer (Linux Foundation / CNCF), date (August 2023)
  - Credential ID: `LF-y7m6yi5kq4`
  - "View Credential" link to LF verification page
- **CSS** matches existing dark theme (same card style, hover effects, cyan/amber accents)
- **Responsive** — stacks vertically on mobile with centered layout
- **Extensible** — grid layout ready for additional cert cards in the future

## Files Changed

| File | Change |
|------|--------|
| `_layouts/default.html` | Added `certifications.html` include |
| `_includes/certifications.html` | New certifications section |
| `assets/style.css` | Certifications CSS (~100 lines) |

## Screenshot

The section uses the same `section-title` pattern with an `mdi:certificate` icon, and the card style mirrors the project cards with hover glow effects.