### PR TITLE
fix: mobile modal overlay coverage over YouTube section

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -96,13 +96,21 @@ document.addEventListener('DOMContentLoaded', function () {
         document.body.appendChild(overlay);
     });
 
+    function closeAllBadgeModals() {
+        document.querySelectorAll('.badge-modal-overlay.active').forEach(function (overlay) {
+            overlay.classList.remove('active');
+        });
+        document.body.classList.remove('badge-modal-open');
+    }
+
     document.querySelectorAll('.badge-pill[data-modal]').forEach(function (pill) {
         pill.addEventListener('click', function () {
             var modalId = this.getAttribute('data-modal');
             var overlay = document.getElementById(modalId);
             if (overlay) {
+                closeAllBadgeModals();
                 overlay.classList.add('active');
-                document.body.style.overflow = 'hidden';
+                document.body.classList.add('badge-modal-open');
             }
         });
     });
@@ -110,11 +118,7 @@ document.addEventListener('DOMContentLoaded', function () {
     // Close modal on X button
     document.querySelectorAll('.badge-modal-close').forEach(function (btn) {
         btn.addEventListener('click', function () {
-            var overlay = this.closest('.badge-modal-overlay');
-            if (overlay) {
-                overlay.classList.remove('active');
-                document.body.style.overflow = '';
-            }
+            closeAllBadgeModals();
         });
     });
 
@@ -122,8 +126,7 @@ document.addEventListener('DOMContentLoaded', function () {
     document.querySelectorAll('.badge-modal-overlay').forEach(function (overlay) {
         overlay.addEventListener('click', function (e) {
             if (e.target === this) {
-                this.classList.remove('active');
-                document.body.style.overflow = '';
+                closeAllBadgeModals();
             }
         });
     });
@@ -131,11 +134,7 @@ document.addEventListener('DOMContentLoaded', function () {
     // Close modal on Escape
     document.addEventListener('keydown', function (e) {
         if (e.key === 'Escape') {
-            var activeModal = document.querySelector('.badge-modal-overlay.active');
-            if (activeModal) {
-                activeModal.classList.remove('active');
-                document.body.style.overflow = '';
-            }
+            closeAllBadgeModals();
         }
     });
 

--- a/assets/script.js
+++ b/assets/script.js
@@ -91,6 +91,11 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     // ===== Badge Pill Modals =====
+    // Move badge modal overlays to <body> so they are never clipped by hero overflow on mobile Safari
+    document.querySelectorAll('.badge-modal-overlay').forEach(function (overlay) {
+        document.body.appendChild(overlay);
+    });
+
     document.querySelectorAll('.badge-pill[data-modal]').forEach(function (pill) {
         pill.addEventListener('click', function () {
             var modalId = this.getAttribute('data-modal');

--- a/assets/style.css
+++ b/assets/style.css
@@ -309,12 +309,12 @@ img {
 
 /* ===== BADGE MODALS ===== */
 .badge-modal-overlay {
-    position: fixed;
+    position: fixed !important;
     inset: 0;
     width: 100vw;
     height: 100dvh;
     min-height: 100vh;
-    z-index: 20000;
+    z-index: 2147483647;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -325,11 +325,16 @@ img {
     pointer-events: none;
     transition: opacity 0.3s ease;
     padding: var(--spacing-sm);
+    isolation: isolate;
 }
 
 .badge-modal-overlay.active {
     opacity: 1;
     pointer-events: auto;
+}
+
+body.badge-modal-open {
+    overflow: hidden;
 }
 
 .badge-modal {

--- a/assets/style.css
+++ b/assets/style.css
@@ -310,11 +310,11 @@ img {
 /* ===== BADGE MODALS ===== */
 .badge-modal-overlay {
     position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    z-index: 10000;
+    inset: 0;
+    width: 100vw;
+    height: 100dvh;
+    min-height: 100vh;
+    z-index: 20000;
     display: flex;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
## Summary
This is a follow-up PR after #14 merge to fix mobile-only modal overlay issues.

## Changes
- Move badge modal overlays to `document.body` at runtime so they cannot be clipped by hero/container overflow contexts on mobile browsers
- Force full viewport overlay coverage (`inset: 0`, `100dvh`, `min-height: 100vh`)
- Increase modal overlay stacking (`z-index: 2147483647`) and add `isolation: isolate`
- Add explicit `body.badge-modal-open` class handling for clean open/close state
- Centralize close behavior via `closeAllBadgeModals()` to prevent stale active overlays

## Why
Desktop behavior was correct, but mobile showed underlying YouTube content above/through the modal. These changes harden stacking and viewport behavior for mobile Safari/Chrome.

## Files
- `assets/script.js`
- `assets/style.css`

## Validation
- Desktop unchanged
- Mobile: modal should fully cover page content, including YouTube area
