### PR TITLE
fix: UI tweaks — bigger flags, about spacing, nav scroll reveal, cert PDFs

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -138,26 +138,28 @@
     }
 }
 /* Homepage nav: hide logo, center links at top */
-.site-nav.home-nav .site-nav-logo {
-    opacity: 0;
-    pointer-events: none;
-    max-width: 0;
-    overflow: hidden;
-    transition: opacity 0.3s ease, max-width 0.3s ease;
-}
-
 .site-nav.home-nav .site-nav-inner {
     justify-content: center;
+    position: relative;
+}
+
+.site-nav.home-nav .site-nav-logo {
+    position: absolute;
+    left: 1.5rem;
+    top: 50%;
+    transform: translateY(-50%);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease;
+}
+
+.site-nav.home-nav.nav-scrolled .site-nav-inner {
+    justify-content: flex-end;
 }
 
 .site-nav.home-nav.nav-scrolled .site-nav-logo {
     opacity: 1;
     pointer-events: auto;
-    max-width: 400px;
-}
-
-.site-nav.home-nav.nav-scrolled .site-nav-inner {
-    justify-content: space-between;
 }
 </style>
 

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -137,6 +137,28 @@
         padding: 0 1rem;
     }
 }
+/* Homepage nav: hide logo, center links at top */
+.site-nav.home-nav .site-nav-logo {
+    opacity: 0;
+    pointer-events: none;
+    max-width: 0;
+    overflow: hidden;
+    transition: opacity 0.3s ease, max-width 0.3s ease;
+}
+
+.site-nav.home-nav .site-nav-inner {
+    justify-content: center;
+}
+
+.site-nav.home-nav.nav-scrolled .site-nav-logo {
+    opacity: 1;
+    pointer-events: auto;
+    max-width: 400px;
+}
+
+.site-nav.home-nav.nav-scrolled .site-nav-inner {
+    justify-content: space-between;
+}
 </style>
 
 <nav class="site-nav" role="navigation" aria-label="Main navigation">

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -233,7 +233,7 @@
                         <p><strong>What it is:</strong> Demonstrates hands-on Kubernetes cluster administration and operations skills.</p>
                         <p><strong>Cert ID:</strong> <code>LF-y7m6yi5kq4</code></p>
                         <p><strong>Issued:</strong> August 2023</p>
-                        <p><a href="https://www.cncf.io/people/verification/" target="_blank" rel="noopener" style="color: var(--color-accent-cyan);">Verify CKA →</a></p>
+                        <p><a href="/assets/ckad-certificate.pdf" target="_blank" rel="noopener" style="color: var(--color-accent-cyan);">View Certificate →</a></p>
                     </div>
                 </div>
                 <div class="cert-card">
@@ -243,7 +243,7 @@
                         <p><strong>What it is:</strong> Linux Foundation orientation for inclusive speaker practices and event participation standards.</p>
                         <p><strong>Cert ID:</strong> <code>LF-f9r7c5xl90</code></p>
                         <p><strong>Issued:</strong> March 24, 2026</p>
-                        <p><a href="https://training.linuxfoundation.org/about/" target="_blank" rel="noopener" style="color: var(--color-accent-cyan);">Learn More →</a></p>
+                        <p><a href="/assets/lfc101-certificate.pdf" target="_blank" rel="noopener" style="color: var(--color-accent-cyan);">View Certificate →</a></p>
                     </div>
                 </div>
             </div>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -196,7 +196,7 @@
 <body>
     {% include nav.html %}
 
-    <main style="max-width: 800px; margin: 0 auto; padding: 0 1.5rem 4rem;">
+    <main style="max-width: 800px; margin: 0 auto; padding: 5rem 1.5rem 4rem;">
         <div class="about-section">
             <h2>About Me</h2>
             <p>I'm Joey Stout — a DevOps engineer, open source tinkerer, and content creator based in Ohio.</p>

--- a/assets/script.js
+++ b/assets/script.js
@@ -87,6 +87,22 @@ document.addEventListener('DOMContentLoaded', function () {
         });
     });
 
+    // ===== Homepage Nav: hide logo at top, show on scroll =====
+    var nav = document.querySelector('.site-nav');
+    var isHomePage = window.location.pathname === '/' || window.location.pathname === '/index.html';
+    if (nav && isHomePage) {
+        nav.classList.add('home-nav');
+        var heroSection = document.getElementById('hero');
+        var scrollThreshold = heroSection ? heroSection.offsetHeight * 0.3 : 200;
+        window.addEventListener('scroll', function () {
+            if (window.scrollY > scrollThreshold) {
+                nav.classList.add('nav-scrolled');
+            } else {
+                nav.classList.remove('nav-scrolled');
+            }
+        }, { passive: true });
+    }
+
     // ===== Hide scroll indicator on scroll =====
     var scrollIndicator = document.querySelector('.scroll-indicator');
     if (scrollIndicator) {

--- a/assets/style.css
+++ b/assets/style.css
@@ -282,13 +282,13 @@ img {
     align-items: center;
     justify-content: center;
     gap: 0;
-    padding: 0.5rem 0.6rem;
+    padding: 0.85rem 1rem;
     border-radius: var(--radius-lg);
     background: var(--color-bg-secondary);
     border: 1px solid var(--color-border);
     color: var(--color-text-secondary);
     font-family: var(--font-heading);
-    font-size: 0.8rem;
+    font-size: 1.4rem;
     font-weight: 500;
     cursor: pointer;
     transition: all var(--transition-normal);
@@ -643,8 +643,8 @@ body.badge-modal-open {
 /* Modal responsive */
 @media (max-width: 767px) {
     .badge-pill {
-        font-size: 0.85rem;
-        padding: 0.45rem 0.55rem;
+        font-size: 1.25rem;
+        padding: 0.75rem 0.9rem;
     }
 
     .badge-modal {


### PR DESCRIPTION
## Changes

1. **Flag buttons ~75% bigger** — font-size 0.8rem→1.4rem, padding scaled up (mobile too)
2. **About page spacing** — 5rem top padding so content isn't tucked under sticky nav
3. **Homepage nav scroll reveal** — hides avatar/name/handle at top (centered links only), reveals on scroll past 30% of hero. Other pages unaffected.
4. **Cert PDF links** — CKA and LFC101 certs now link to the actual PDFs in the repo