### PR TITLE
fix: remove avatar from blog post pages

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -55,21 +55,8 @@
 <body>
     {% include nav.html %}
 
-    <!-- Minimal Hero / Nav Header -->
-    <section id="hero" class="hero" style="min-height: unset; padding: 2rem 0;">
-        <div class="hero-content">
-            <a href="/" style="display: block; width: 80px; margin: 0 auto 1rem;">
-            <div class="hero-avatar-wrapper" style="width: 80px; height: 80px;">
-                <img class="hero-avatar" style="width: 80px; height: 80px;" src="{{ site.logo }}" alt="{{ site.name }}">
-            </div>
-            </a>
-            <h1 class="hero-title" style="font-size: 1.5rem;">{{ site.name }}</h1>
-            <p class="hero-handle"><span class="code-name">{{ site.tagline }}</span></p>
-        </div>
-    </section>
-
     <!-- Post Content -->
-    <main style="max-width: 800px; margin: 0 auto; padding: 2rem 1.5rem;">
+    <main style="max-width: 800px; margin: 0 auto; padding: 5rem 1.5rem 2rem;">
         <article>
             {% if page.image %}
             <div style="margin-bottom: 2rem; border-radius: var(--radius-md); overflow: hidden;">


### PR DESCRIPTION
Removes the mini hero section (avatar + name + handle) from individual blog post pages. The nav already shows the logo, so it was redundant. Added 5rem top padding to clear the sticky nav.