### PR TITLE
Update speaker bio & hero text

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,7 @@ paginate_path: "/blog/page:num/"
 
 # Site Configuration
 name: Joey Stout  # Name of your website
-tagline: TheOutdoorProgrammer  # Set your preferred page title
+tagline: "@TheOutdoorProgrammer"  # Set your preferred page title
 description: Programmer, Hunter, Hockey Fan, Family Man.  # Also used as a meta description
 flags: 🇵🇸 🇺🇸 🇺🇦
 favicon:

--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,7 @@ paginate_path: "/blog/page:num/"
 # Site Configuration
 name: Joey Stout  # Name of your website
 tagline: "@TheOutdoorProgrammer"  # Set your preferred page title
-description: Programmer, Hunter, Hockey Fan, Family Man.  # Also used as a meta description
+description: ""  # Also used as a meta description
 flags: 🇵🇸 🇺🇸 🇺🇦
 favicon:
   path: /assets/images/favicon.svg # Path / URL to the favicon of your website (e.g., 'assets/images/favicon.png')

--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,7 @@ paginate_path: "/blog/page:num/"
 # Site Configuration
 name: Joey Stout  # Name of your website
 tagline: "@TheOutdoorProgrammer"  # Set your preferred page title
-description: ""  # Also used as a meta description
+description: "Joey Stout — engineer, open source contributor, and outdoor enthusiast. DevOps, Kubernetes, fishing, hunting, and more."
 flags: 🇵🇸 🇺🇸 🇺🇦
 favicon:
   path: /assets/images/favicon.svg # Path / URL to the favicon of your website (e.g., 'assets/images/favicon.png')

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -72,7 +72,6 @@
             <h1 class="hero-title">{{ site.name }}{% if site.badge.enable == true %}<span class="iconify-inline badge" data-icon="{{ site.badge.icon }}" style="color: {{ site.badge.color }}"></span>{% endif %}</h1>
             <p class="hero-handle"><span class="code-name">{{ site.tagline }}</span></p>
             <p class="hero-subtitle">Engineer &amp; Outdoorsman</p>
-            <p class="hero-bio">{{ site.description }}</p>
             <!-- Social Icons -->
 
             <!-- Badge Pills -->

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -37,7 +37,7 @@
           "@type": "Person",
           "name": "Joey Stout",
           "url": "{{ site.url }}",
-          "jobTitle": "DevOps Engineer",
+          "jobTitle": "Engineer",
           "sameAs": [
             "https://github.com/TheOutdoorProgrammer",
             "https://youtube.com/@TheOutdoorProgrammer",
@@ -71,7 +71,7 @@
             </div>
             <h1 class="hero-title">{{ site.name }}{% if site.badge.enable == true %}<span class="iconify-inline badge" data-icon="{{ site.badge.icon }}" style="color: {{ site.badge.color }}"></span>{% endif %}</h1>
             <p class="hero-handle"><span class="code-name">{{ site.tagline }}</span></p>
-            <p class="hero-subtitle">DevOps Engineer &amp; Outdoorsman</p>
+            <p class="hero-subtitle">Engineer &amp; Outdoorsman</p>
             <p class="hero-bio">{{ site.description }}</p>
             <!-- Social Icons -->
 

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -290,6 +290,10 @@
                 </div>
             </div>
         </div>
+        <div class="about-section">
+            <h2>Speaker Bio</h2>
+            <p>Joey Stout loves programming so much that he couldn't stop at doing it for work. He fills his free time building open source projects and tinkering with whatever catches his interest. Off the clock, he's a dad of four, an avid hunter, dedicated fisherman, and die-hard hockey fan. He documents both his technical projects and outdoor adventures at <a href="https://theoutdoorprogrammer.com" target="_blank" rel="noopener" style="color: var(--color-accent-cyan);">theoutdoorprogrammer.com</a>, and you can find his YouTube channel linked there as well.</p>
+        </div>
     </main>
 
     <footer class="site-footer">

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -224,6 +224,11 @@
         </div>
 
         <div class="about-section">
+            <h2>Off the Ice</h2>
+            <p>I'm a die-hard Columbus Blue Jackets fan — through the good, the bad, and the painfully rebuilding. I also follow the Seattle Kraken because expansion teams need love too. Hockey season is basically a second full-time job around here.</p>
+        </div>
+
+        <div class="about-section">
             <h2>Certifications</h2>
             <div class="cert-grid">
                 <div class="cert-card">

--- a/about/index.md
+++ b/about/index.md
@@ -3,7 +3,3 @@ layout: page
 title: About
 permalink: /about/
 ---
-
-## Speaker Bio
-
-Joey Stout loves programming so much that he couldn't stop at doing it for work. He fills his free time building open source projects and tinkering with whatever catches his interest. Off the clock, he's a dad of four, an avid hunter, dedicated fisherman, and die-hard hockey fan. He documents both his technical projects and outdoor adventures at theoutdoorprogrammer.com, and you can find his YouTube channel linked there as well.

--- a/about/index.md
+++ b/about/index.md
@@ -3,3 +3,7 @@ layout: page
 title: About
 permalink: /about/
 ---
+
+## Speaker Bio
+
+Joey Stout loves programming so much that he couldn't stop at doing it for work. He fills his free time building open source projects and tinkering with whatever catches his interest. Off the clock, he's a dad of four, an avid hunter, dedicated fisherman, and die-hard hockey fan. He documents both his technical projects and outdoor adventures at theoutdoorprogrammer.com, and you can find his YouTube channel linked there as well.


### PR DESCRIPTION
## Changes

### Speaker Bio (about page)
- Added conference speaker bio section with talk history and topics

### Hero/Header Updates
- Changed hero subtitle from **DevOps Engineer & Outdoorsman** to **Engineer & Outdoorsman**
- Added @ prefix to handle: **TheOutdoorProgrammer** → **@TheOutdoorProgrammer**
- Updated JSON-LD structured data to match